### PR TITLE
zustand 상태 관리 스토어 생성

### DIFF
--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+import { persist, devtools } from 'zustand/middleware';
+import { useShallow } from 'zustand/shallow';
+
+// 사용자 상태 (로컬스토리지로 관리)
+const userStore = devtools(
+  persist(
+    (set) => ({
+      userId: null, // 사용자 ID
+      setUserId: (id) => {
+        set({ userId: id });
+        localStorage.setItem('userId', id);
+      },
+    }),
+    { name: 'user-storage' },
+  ),
+);
+
+// 피드 상태
+const feedStore = devtools((set) => ({
+  feedList: [], // 질문함 목록 (get /{team}/subjects)
+  order: 'latest', // 정렬
+  currentPage: 1, // 현재 페이지
+  selectedFeed: null, // 선택한 피드 (feedDetail)
+  questions: {}, // 선택한 피드의 질문 목록
+  selectedQuestion: null, // 답변중인 질문
+  modalVisible: false, // 모달창이 활성화된 상태인지
+  // 좋아요 등 추가 상태
+
+  setFeedList: (feeds) => set({ feedList: feeds }),
+  setOrder: (order) => set({ order }),
+  setCurrentPage: (page) => set({ currentPage: page }),
+  setSelectedFeed: (feedId) => set({ selectedFeed: feedId }),
+  setQuestions: (feedId, questions) =>
+    set((state) => ({ questions: { ...state.questions, [feedId]: questions } })),
+  setSelectedQuestion: (questionId) => set({ selectedQuestion: questionId }),
+  setModalVisible: () => set((state) => ({ modalVisible: !state.modalVisible })),
+}));
+
+// 스토어 생성
+const useUserStore = create(userStore);
+const useFeedStore = create(feedStore);
+
+// User 관련 스토어
+export const useUser = () => useUserStore(useShallow((state) => state));
+
+// Feed 관련 스토어
+export const useFeed = () => {
+  return useFeedStore(useShallow((state) => state));
+};


### PR DESCRIPTION
## 작업 내용

- 상태 관리를 할 수 있는 일종의 보관함인 스토어를 생성했습니다
- userStore에서는 로컬스토리지로 관리할 사용자 상태, feedStore에서는 그 외 상태를 추가했습니다
- 관련 문서를 만들었습니다 [상태 사용하기](https://1bitegoonbam.notion.site/Zustand-12d5a6376e0b807b887ff84e0cfd1be0)

## 이슈 번호

- 관련 이슈: `#17`

## 변경 사항

- hooks/useStore.js 파일 추가

## 리뷰 포인트

- 현재는 제가 생각했을때 필요할 것 같은 상태만 추가해두었습니다. 추후에 수정이 필요할 것 같습니다

## 참고 사항 (Screenshots/References)

- 테스트 이미지를 첨부합니다
![스크린샷 2024-10-28 오후 4 11 08](https://github.com/user-attachments/assets/8fd0c7e2-69e5-42f2-b93e-653acb63e813)

## 기타 사항 (Additional Context)

- 상태가 수정되거나 추가되는 경우 어떤 방식으로 팀원들에게 알릴지 논의해봐야 할 것 같습니다 (해당 상태를 다른 팀원의 작업 영역에서도 공유하고 있는 경우에는 최신화가 필요할 것 같습니다)
