### PR TITLE
Feature/1--styles브랜치에서 Globalstyles, theme, App.js 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet": "^6.1.0",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.13",

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,24 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import theme from './styles/theme';
+import GlobalStyles from './styles/GlobalStyles';
+import { Helmet } from 'react-helmet';
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route />
-      </Routes>
-    </Router>
+    <>
+      <Helmet>
+        <link href='https://fonts.googleapis.com/css2?family=Actor&display=swap' rel='stylesheet' />
+      </Helmet>
+      <ThemeProvider theme={theme}>
+        <GlobalStyles />
+        <Router>
+          <Routes>
+            <Route />
+          </Routes>
+        </Router>
+      </ThemeProvider>
+    </>
   );
 }
 

--- a/src/styles/GlobalStyles.jsx
+++ b/src/styles/GlobalStyles.jsx
@@ -1,9 +1,8 @@
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
-import { theme } from './theme.jsx';
 
 const GlobalStyles = createGlobalStyle`
-  @import url('https://fonts.googleapis.com/css2?family=Actor&display=swap');
+  
 
   ${reset} // reset.css 적용
   
@@ -22,14 +21,18 @@ const GlobalStyles = createGlobalStyle`
 
   body {
     font-family: 'Pretendard-Regular', sans-serif;
-    background-color: ${theme.gray[10]}; 
-    font-size: ${theme.typography.body3.fontSize}; 
-    color: ${theme.gray[60]};
+    background-color: ${({ theme }) => theme.gray[10]}; 
+    font-size: ${({ theme }) => theme.typography.body3.fontSize}; 
+    color: ${({ theme }) => theme.gray[60]};
+  }
+
+  div, h1, h2, h3, h4, h5, h6, p, ol, li, a, form, input, button {
+    font-family: 'Pretendard-Regular', sans-serif;
   }
 
   a {
     text-decoration: none;
-    color: ${theme.gray[60]};
+    color: ${({ theme }) => theme.gray[60]};
   }
   
   li {

--- a/src/styles/theme.jsx
+++ b/src/styles/theme.jsx
@@ -1,4 +1,4 @@
-export const theme = {
+const theme = {
   gray: {
     10: '#FFFFFF',
     20: '#F9F9F9',
@@ -24,31 +24,31 @@ export const theme = {
   },
   typography: {
     h1: {
-      fontSize: '2.5rem',
+      fontSize: '2.5rem', // 40px
       fontWeight: 'bold',
     },
     h2: {
-      fontSize: '2rem',
+      fontSize: '2rem', // 32px
       fontWeight: 'bold',
     },
     h3: {
-      fontSize: '1.5rem',
+      fontSize: '1.5rem', // 24px
       fontWeight: 'bold',
     },
     body1: {
-      fontSize: '1.25rem',
+      fontSize: '1.25rem', // 20px
       fontWeight: 'normal',
     },
     body1Bold: {
-      fontSize: '1.25rem',
+      fontSize: '1.25rem', // 20px
       fontWeight: 'bold',
     },
     body2: {
-      fontSize: '1.125rem',
+      fontSize: '1.125rem', // 18px
       fontWeight: 'normal',
     },
     body2Bold: {
-      fontSize: '1.125rem',
+      fontSize: '1.125rem', // 18px
       fontWeight: 'bold',
     },
     body3: {
@@ -73,3 +73,4 @@ export const theme = {
     },
   },
 };
+export default theme;


### PR DESCRIPTION
## 작업 내용

- App.js에 ThemeProvider으로 theme을 적용하여 각 컴퍼넌트에서 theme.jsx를 import를 안해도 사용하게끔 수정완료
- App.js에 GlobalStyles 적용되게끔 코드 수정
- react-helmet 설치하여 Helmet안에 구글폰트를 Link로 변경

## 이슈 번호

- 관련 이슈: `#029`
 

## 변경 사항

- App.js에 공통css들을 적용을 못하고 merge한 부분들을 적용을 시켜서 넣었습니다.
- GlobalStyles에서 reset.css를 설치하고 가져오는 과정에서 body테그에 있는 폰트들이 안먹는걸 확인하여 따로 코드들을 추가하였습니다.
- GlobalStyles에서 구글폰트를 import을 하니 콘솔에 오류가 생겨 App.js에 Helmet을 설치하고 안에 link로 넣었습니다.
- theme에 있는 rem의 px값을 옆에 주석으로 적어놨습니다.

## 리뷰 포인트

- develop에서 최신화 하시고 문제가 없으신지 확인부탁드립니다.

## 참고 사항 (Screenshots/References)
- X

## 기타 사항 (Additional Context)

- 한번더 확인했어야 했는데 불편하게 해서 죄송합니다ㅜㅜ
