### PR TITLE
질문 작성 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ function App() {
             <Route index element={<HomePage />} />
             <Route path='/list' element={<FeedList />} />
             <Route path='/post/:id' element={<FeedDetailPage />} />
+            <Route path='/post/:id/answer' element={<FeedDetailPage />} />
           </Routes>
         </Router>
       </ThemeProvider>

--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://openmind-api.vercel.app/11-6';
+const TEAM = '11-6';
+const DEFAULT_HEADERS = {
+  'Content-Type': 'application/json',
+};
+
+// Post
+export async function createQuestions(subjectId, content) {
+  const params = {
+    subjectId,
+    content,
+    like: 0,
+    dislike: 0,
+    team: TEAM,
+    answer: {},
+  };
+
+  try {
+    const response = await axios.post(`${BASE_URL}/subjects/${subjectId}/questions/`, params, {
+      headers: DEFAULT_HEADERS,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error creating questions:', error);
+  }
+}
+
+// GET
+export async function getQuestions(subjectId) {
+  try {
+    const response = await axios.get(`${BASE_URL}/subjects/${subjectId}/questions/`, {
+      headers: DEFAULT_HEADERS,
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching questions:', error);
+  }
+}

--- a/src/api/subjectApi.js
+++ b/src/api/subjectApi.js
@@ -45,30 +45,12 @@ export async function getSubjects({ sort, page, pageSize } = {}) {
 
 export async function getSubjectById(subjectId) {
   try {
-    const response = await axios.get(
-      `${'https://openmind-api.vercel.app/11-6'}/subjects/${subjectId}/`,
-      {
-        headers: DEFAULT_HEADERS,
-      },
-    );
+    const response = await axios.get(`${BASE_URL}/subjects/${subjectId}/`, {
+      headers: DEFAULT_HEADERS,
+    });
 
     return response.data;
   } catch (error) {
     console.error('Error fetching subject:', error);
-  }
-}
-
-export async function getQuestionsBySubject(subjectId) {
-  try {
-    const response = await axios.get(
-      `${'https://openmind-api.vercel.app/11-6'}/subjects/${subjectId}/questions/`,
-      {
-        headers: DEFAULT_HEADERS,
-      },
-    );
-
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching questions:', error);
   }
 }

--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useState } from 'react';
+import { createQuestions } from '../../api/questionApi';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -122,11 +123,23 @@ const QuestionRegisterButton = styled.button`
   }
 `;
 
-function CreateQuestionModal({ image, name, onClose }) {
+function CreateQuestionModal({ id, image, name, setIsQuestionSubmitted, onClose }) {
   const [questionText, setQuestionText] = useState('');
 
   const handleChange = (event) => {
     setQuestionText(event.target.value);
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await createQuestions(id, questionText);
+      alert('질문이 성공적으로 전송되었습니다.');
+      setIsQuestionSubmitted(true);
+      onClose();
+      window.location.reload();
+    } catch (error) {
+      alert('질문 전송에 실패했습니다. 다시 시도해 주세요.');
+    }
   };
 
   const isButtonDisabled = questionText.trim() === '';
@@ -154,7 +167,9 @@ function CreateQuestionModal({ image, name, onClose }) {
           onChange={handleChange}
         />
 
-        <QuestionRegisterButton disabled={isButtonDisabled}>질문 보내기</QuestionRegisterButton>
+        <QuestionRegisterButton onClick={handleSubmit} disabled={isButtonDisabled}>
+          질문 보내기
+        </QuestionRegisterButton>
       </ModalContainer>
     </ModalOverlay>
   );

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -12,7 +12,7 @@ const Main = styled.main`
   flex-direction: column;
   align-items: center;
   padding: 0 24px;
-  margin-top: 174px;
+  margin-top: 54px;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     padding: 0 32px;

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -3,7 +3,8 @@ import Header from './Header.jsx';
 
 import { useEffect, useState } from 'react';
 import CreateQuestionModal from './CreateQuestionModal.jsx';
-import { getQuestionsBySubject, getSubjectById } from '../../api/subjectApi.js';
+import { getSubjectById } from '../../api/subjectApi.js';
+import { getQuestions } from '../../api/questionApi.js';
 import { useParams } from 'react-router-dom';
 
 const Main = styled.main`
@@ -108,8 +109,11 @@ function FeedDetailPage() {
   const [questions, setQuestions] = useState([]);
   const [questionsCount, setQuestionsCount] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isQuestionSubmitted, setIsQuestionSubmitted] = useState(true);
 
   useEffect(() => {
+    if (!isQuestionSubmitted) return;
+
     const fetchSubject = async () => {
       const response = await getSubjectById(id);
       setSubject(response);
@@ -118,7 +122,7 @@ function FeedDetailPage() {
     };
 
     const fetchQuestions = async () => {
-      const response = await getQuestionsBySubject(id);
+      const response = await getQuestions(id);
       const { count, results } = response;
 
       setQuestions(results);
@@ -129,7 +133,8 @@ function FeedDetailPage() {
 
     fetchSubject();
     fetchQuestions();
-  }, [id]);
+    setIsQuestionSubmitted(false);
+  }, [id, isQuestionSubmitted]);
 
   const handleOpenModal = () => {
     setIsModalOpen(true);
@@ -151,7 +156,7 @@ function FeedDetailPage() {
                 <QuestionCountText>{`${questionsCount}개의 질문이 있습니다.`}</QuestionCountText>
               </QuestionCounterContainer>
 
-              {questions}
+              {console.log(questions)}
             </>
           ) : (
             <>
@@ -168,8 +173,10 @@ function FeedDetailPage() {
 
         {isModalOpen && (
           <CreateQuestionModal
+            id={id}
             image={subject.imageSource}
             name={subject.name}
+            setIsQuestionSubmitted={setIsQuestionSubmitted}
             onClose={handleCloseModal}
           />
         )}

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -104,7 +104,7 @@ const CreateQuestionBtn = styled.button`
 `;
 
 function FeedDetailPage() {
-  const { id } = useParams();
+  const { id, answer } = useParams();
   const [subject, setSubject] = useState({});
   const [questions, setQuestions] = useState([]);
   const [questionsCount, setQuestionsCount] = useState(0);
@@ -157,6 +157,7 @@ function FeedDetailPage() {
               </QuestionCounterContainer>
 
               {console.log(questions)}
+              {console.log(answer)}
             </>
           ) : (
             <>

--- a/src/pages/FeedDetail/Header.jsx
+++ b/src/pages/FeedDetail/Header.jsx
@@ -1,26 +1,30 @@
 import styled, { keyframes } from 'styled-components';
 import { shareKakao } from '../../utills/KakaoShare';
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const HeaderContainer = styled.header`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-image: url('/images/backgrounds/feed-detail-header.svg');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  width: 100%;
-  height: 180px;
+  position: relative;
+`;
+
+const BackGroundImage = styled.img`
+  height: 178px;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     height: 234px;
   }
 `;
 
+const LogoWrapper = styled(Link)`
+  margin-top: 40px;
+  position: absolute;
+`;
+
 const Logo = styled.img`
   height: 50px;
-  margin-top: 40px;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     height: 68px;
@@ -29,17 +33,19 @@ const Logo = styled.img`
 
 const ProfileImage = styled.img`
   height: 104px;
-  margin-top: 10px;
+  margin-top: 100px;
   border-radius: 50%;
+  position: absolute;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
+    margin-top: 130px;
     height: 136px;
     width: 136px;
   }
 `;
 
 const UserName = styled.h1`
-  margin: 12px 0 0 0;
+  margin-top: 40px;
   font-weight: 400;
   font-size: ${({ theme }) => theme.typography.h3.fontSize};
   line-height: 1.875rem;
@@ -47,6 +53,7 @@ const UserName = styled.h1`
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     font-size: ${({ theme }) => theme.typography.h2.fontSize};
     line-height: 2.5rem;
+    margin-top: 46px;
   }
 `;
 
@@ -108,7 +115,10 @@ function Header({ image, name }) {
 
   return (
     <HeaderContainer>
-      <Logo src='/images/contents/logo.svg' />
+      <BackGroundImage src='/images/backgrounds/feed-detail-header.svg' />
+      <LogoWrapper to='/'>
+        <Logo src='/images/contents/logo.svg' />
+      </LogoWrapper>
       <ProfileImage src={image} />
       <UserName>{name}</UserName>
       <ShareContainer>


### PR DESCRIPTION
## 작업 내용
- 헤더 스타일 조정
- 질문 작성 api구현
- answer 경로 추가

## 변경 사항
- 헤더 로고를 클릭 시 홈페이지로 이동
- 헤더의 `userName`과 공유 버튼들이 컨테이너 box의 외부에 표시되어 드래그가 제대로 되지 않던 오류를 해결하기 위해 필요한 요소들을 `absolute`로 포지셔닝
- questionApi.js파일 생성
  -  subjectApi.js로부터 `getQuestions()` 를 분리하여 가져옴
  - `createQuestion()` 구현
- `/post/id/answer/`경로를 `Route`에 추가하여 홈페이지에서 질문 받기를 누르면 생성된 피드의 answer 페이지로 이동
- 
## 리뷰 포인트
- 배포 하고 나면 이제 질문 작성 기능이 정상적으로 작동하고, 아직 박스가 없어 내용은 볼 수 없지만 몇 개의 질문이 있는지는 표시되도록 했습니다.
- answer경로에 몇 가지 조건부 랜더링을 추가해야 합니다. 질문 박스 추가하면서 작업하겠습니다.

## 참고 사항 (Screenshots/References)
![image](https://github.com/user-attachments/assets/392f08e9-a04f-4ddd-8740-562c1a886439)

