### PR TITLE
feat: 상태 및 이벤트 구현, 데이터 연동

### DIFF
--- a/src/api/answerApi.js
+++ b/src/api/answerApi.js
@@ -1,0 +1,47 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://openmind-api.vercel.app/11-6';
+const DEFAULT_HEADERS = {
+  'Content-Type': 'application/json',
+};
+
+// GET
+export async function getAnswerById(answerId) {
+  try {
+    const response = await axios.get(`${BASE_URL}/answers/${answerId}/`, {
+      headers: DEFAULT_HEADERS,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching answer:', error);
+  }
+}
+
+// PATCH
+export async function updateAnswer(answerId, content, isRejected = false) {
+  try {
+    const response = await axios.patch(
+      `${BASE_URL}/answers/${answerId}/`,
+      {
+        content,
+        isRejected,
+      },
+      { headers: DEFAULT_HEADERS },
+    );
+    console.log('답변 수정');
+    return response.data;
+  } catch (error) {
+    console.error('Error updating answer:', error);
+  }
+}
+
+// DELETE
+export async function deleteAnswer(answerId) {
+  try {
+    await axios.delete(`${BASE_URL}/answers/${answerId}/`, {
+      headers: DEFAULT_HEADERS,
+    });
+  } catch (error) {
+    console.error('Error deleting answer:', error);
+  }
+}

--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://openmind-api.vercel.app/11-6';
+const DEFAULT_HEADERS = {
+  'Content-Type': 'application/json',
+};
+
+export const createAnswer = async ({ questionId, content, isRejected = false }) => {
+  try {
+    const response = await axios.post(
+      `${BASE_URL}/questions/${questionId}/answers/`,
+      {
+        questionId,
+        content,
+        isRejected,
+        team: '11-6',
+      },
+      { headers: DEFAULT_HEADERS },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error creating answer:', error);
+  }
+};
+
+export const createReaction = async ({ id, type }) => {
+  try {
+    const response = await axios.post(
+      `${BASE_URL}/questions/${id}/reaction/`,
+      {
+        type,
+      },
+      { headers: DEFAULT_HEADERS },
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error updating reaction:', error);
+  }
+};

--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -41,6 +41,7 @@ export async function getQuestions(subjectId) {
   }
 }
 
+// 답변 POST
 export const createAnswer = async ({ questionId, content, isRejected = false }) => {
   const params = {
     questionId,
@@ -59,6 +60,7 @@ export const createAnswer = async ({ questionId, content, isRejected = false }) 
   }
 };
 
+// 좋아요 POST
 export const createReaction = async ({ id, type }) => {
   const params = {
     type,

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import CreateQuestionModal from './CreateQuestionModal.jsx';
 import { getQuestionsBySubject, getSubjectById } from '../../api/subjectApi.js';
 import { useParams } from 'react-router-dom';
+import QuestionBox from './QuestionBox.jsx';
 
 const Main = styled.main`
   height: 100%;
@@ -151,7 +152,14 @@ function FeedDetailPage() {
                 <QuestionCountText>{`${questionsCount}개의 질문이 있습니다.`}</QuestionCountText>
               </QuestionCounterContainer>
 
-              {questions}
+              {questions.map((question) => (
+                <QuestionBox
+                  key={question.id}
+                  question={question}
+                  image={subject.imageSource}
+                  name={subject.name}
+                />
+              ))}
             </>
           ) : (
             <>


### PR DESCRIPTION
## 작업 내용

- 지저분한 상태와 이벤트 수정
- api 데이터 연동

## 이슈 번호

- 관련 이슈: #25

## 리뷰 포인트

- 각 기능이 잘 동작하는지 봐주시면 됩니다. 제 나름대로 테스트를 했는데 보지 못한 부분도 있을 것 같습니다
- 질문자인지 답변자인지 구분하는 로직이 어디에 있는지 확인을 못했는데, 질문자인지 답변자인지 넘겨받으면 조건부 렌더링 할 수 있도록 로직 나눠두었습니다 (아마 post/{id}와 post/{id}/answer가 나뉘는 부분이겠지요..?)
- 코드 분리는 차차 하겠습니다 

## 기타 사항 (Additional Context)

- 좋아요 싫어요 부분은 api 함수 작성, 가져오는 것 까지는 잘 동작했지만, 원하는 대로 로직을 구현하는데 어려움을 겪어서 잠시 주석처리 했습니다
- 저희가 원하는 방식은 둘 중 하나만 클릭할 수 있어야 하고, 버튼을 다시 누르면 해제할 수 있어야 하고, 한번씩만 누를 수 있어야 하는데 api문서 상 POST /{team}/questions/{id}/reaction/ 으로 해당 반응을 추가하는 것 밖에 작동하지 않아 어떻게 구현해야 할 지 고민입니다 (이전 팀이 왜 그렇게밖에 할 수 없었는지 이해했습니다. 이 부분 논의가 필요할 것 같습니다)
- 질문 데이터가 수정 가능하면 어떻게든 접근해서 수정했을 것 같은데, 수정은 답변밖에 할 수가 없네요..

