### PR TITLE
feat: 경로별 조건부 렌더링 추가

### DIFF
--- a/src/pages/FeedDetail/QuestionBox.jsx
+++ b/src/pages/FeedDetail/QuestionBox.jsx
@@ -4,6 +4,7 @@ import ThumbsDownIcon from './SvgIcons/thumbs-down';
 import { useEffect, useRef, useState } from 'react';
 import { getAnswerById, updateAnswer, deleteAnswer } from '../../api/answerApi';
 import { createAnswer } from '../../api/questionApi';
+import { useLocation } from 'react-router-dom';
 
 const QuestionCard = styled.div`
   display: flex;
@@ -266,13 +267,16 @@ const getRelativeTime = (dateString) => {
   return '방금 전';
 };
 
-export default function QuestionBox({ question, image, name, isFeedOwner = true }) {
+export default function QuestionBox({ question, image, name }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [currentAnswer, setCurrentAnswer] = useState(question.answer);
   const [isEditing, setIsEditing] = useState(false);
   const [answerText, setAnswerText] = useState('');
   const [isLiked, setIsLiked] = useState(false);
   const [isDisliked, setIsDisliked] = useState(false);
+
+  const location = useLocation();
+  const isFeedOwner = location.pathname.includes('/post') && location.pathname.includes('/answer');
 
   const handleToggleMenu = () => {
     setMenuOpen((prev) => !prev);


### PR DESCRIPTION
## 작업 내용

- /post/:id일때와 /post/:id/answer일 때 다르게 렌더링 하기 위해 일단 경로별로 다르게 렌더링 하는 것으로 했습니다 (추후 로컬스토리지로 확인하는 부분이 잘 작동되면 수정하겠습니다)

## 이슈 번호

- 관련 이슈: `#25`

## 리뷰 포인트

- /post/:id일때와 /post/:id/answer일 때 조건부 렌더링이 잘 되는지
- 제가 확인했을 때 /post/:id일 때 답변 거절일 경우 색상 반영이 안 되어서 나중에 수정하겠습니다!

## 기타 사항 (Additional Context)

- 멘토링 때 배포 페이지 확인하기 편하시라고 우선 이렇게 구현해두었습니다. 추후 로컬스토리지에 저장된 id에 따라 다르게 보여줄 수 있도록 하겠습니다!
