### PR TITLE
Feedlist 부분 Card의 이미지가 Dark모드로 변경했을때 이상하게 보여서 Card.jsx에 css추가

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -43,6 +43,7 @@ const CardImage = styled.img`
   width: 48px;
   height: 48px;
   border-radius: 50%;
+  mix-blend-mode: ${(props) => props.theme.mixBlendMode};
 
   @media (min-width: 768px) {
     width: 60px;


### PR DESCRIPTION
## 작업 내용

- Feedlist 부분 Card의 이미지가 Dark모드로 변경했을때 이상하게 보여서 Card.jsx에 css추가

## 이슈 번호

- 관련 이슈: `#064`
  - 추가설명에 이슈기제했습니다.

## 변경 사항
```
const CardImage = styled.img`
mix-blend-mode: ${(props) => props.theme.mixBlendMode};  //추가
`;
```

## 리뷰 포인트

- 잘 적용이 되는지 확인부탁드립니다!

## 참고 사항 (Screenshots/References)

라이트 모드
![image](https://github.com/user-attachments/assets/b4e4399a-c642-4b7a-8e14-3400063a56cd)

다크 모드
![image](https://github.com/user-attachments/assets/38b80e0d-76b9-4ce9-ac48-538f953957ff)

## 기타 사항 (Additional Context)

- X
