### PR TITLE
answer 경로 검증 작업 완료

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { lightTheme, darkTheme } from './styles/theme';
 import GlobalStyles from './styles/GlobalStyles';
@@ -8,6 +8,7 @@ import FeedList from './pages/FeedList/FeedList';
 import FeedDetailPage from './pages/FeedDetail/FeedDetailPage';
 import ToggleThemeBtn from './components/ToggleTheme';
 import { useState } from 'react';
+import ForbiddenPage from './pages/Errors/ForbiddenPage';
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -35,7 +36,9 @@ function App() {
             <Route index element={<HomePage />} />
             <Route path='/list' element={<FeedList />} />
             <Route path='/post/:id' element={<FeedDetailPage />} />
-            <Route path='/post/:id/answer' element={<FeedDetailPage />} />
+            <Route path='/post/:id/answer' element={<FeedDetailPage isAnswer={true} />} />
+            <Route path='/403' element={<ForbiddenPage />} />
+            <Route path='*' element={<Navigate to='/' replace />} />
           </Routes>
         </Router>
       </ThemeProvider>

--- a/src/hooks/useStore.js
+++ b/src/hooks/useStore.js
@@ -2,14 +2,31 @@ import { create } from 'zustand';
 import { persist, devtools } from 'zustand/middleware';
 import { useShallow } from 'zustand/shallow';
 
-// 사용자 상태 (로컬스토리지로 관리)
 const userStore = devtools(
   persist(
-    (set) => ({
-      userId: null, // 사용자 ID
-      setUserId: (id) => {
-        set({ userId: id });
-        localStorage.setItem('userId', id);
+    (set, get) => ({
+      users: {}, // 사용자 정보를 { id: name } 형태로 저장
+
+      // 새로운 사용자 추가 또는 기존 사용자 업데이트
+      setUser: (id, name) => {
+        const updatedUsers = { ...get().users, [id]: name };
+        set({ users: updatedUsers });
+      },
+
+      // 특정 사용자 정보 가져오기
+      getUser: (id) => get().users[id],
+
+      // 사용자 삭제 기능
+      removeUser: (id) => {
+        const updatedUsers = { ...get().users };
+        delete updatedUsers[id];
+        set({ users: updatedUsers });
+      },
+
+      // 피드 수정 권한 확인
+      canEditFeed: (feedOwnerId) => {
+        // feedOwnerId가 로컬 스토리지에 저장된 사용자인지 확인
+        return Boolean(get().users[feedOwnerId]);
       },
     }),
     { name: 'user-storage' },

--- a/src/pages/Errors/ForbiddenPage.jsx
+++ b/src/pages/Errors/ForbiddenPage.jsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+function ForbiddenPage() {
+  const navigate = useNavigate();
+
+  const handleGoHome = () => {
+    navigate('/');
+  };
+
+  return (
+    <ForbiddenPageContainer>
+      <ErrorMessage>403 - 접근 권한이 없습니다</ErrorMessage>
+      <ErrorDescription>이 페이지에 접근할 권한이 없습니다.</ErrorDescription>
+      <HomeButton onClick={handleGoHome}>홈으로 돌아가기</HomeButton>
+    </ForbiddenPageContainer>
+  );
+}
+
+export default ForbiddenPage;
+
+const ForbiddenPageContainer = styled.div`
+  height: 100%;
+  width: 100%;
+  padding: 40px 24px;
+  margin: 100px auto;
+  text-align: center;
+  border-radius: 16px;
+  position: relative;
+  z-index: 2;
+
+  @media (min-width: 768px) {
+    max-width: 460px;
+    padding: 48px 32px;
+  }
+`;
+
+const ErrorMessage = styled.h1`
+  font-size: ${({ theme }) => theme.typography.h3.fontSize};
+  color: ${({ theme }) => theme.red};
+  margin-bottom: 16px;
+`;
+
+const ErrorDescription = styled.p`
+  font-size: ${({ theme }) => theme.typography.body2.fontSize};
+  color: ${({ theme }) => theme.gray[70]};
+  margin-bottom: 24px;
+`;
+
+const HomeButton = styled.button`
+  width: 100%;
+  padding: 12px 0;
+  border: none;
+  border-radius: 8px;
+  background-color: ${({ theme }) => theme.brown[40]};
+  color: ${({ theme }) => theme.gray[10]};
+  font-size: ${({ theme }) => theme.typography.body3.fontSize};
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.brown[50]};
+  }
+`;

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -5,8 +5,9 @@ import { useEffect, useState } from 'react';
 import CreateQuestionModal from './CreateQuestionModal.jsx';
 import { getSubjectById } from '../../api/subjectApi.js';
 import { getQuestions } from '../../api/questionApi.js';
-import { useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import QuestionBox from './QuestionBox.jsx';
+import { useUser } from '../../hooks/useStore.js';
 
 const Main = styled.main`
   height: 100%;
@@ -104,36 +105,48 @@ const CreateQuestionBtn = styled.button`
   }
 `;
 
-function FeedDetailPage() {
-  const { id, answer } = useParams();
+function FeedDetailPage({ isAnswer }) {
+  const { id } = useParams();
   const [subject, setSubject] = useState({});
   const [questions, setQuestions] = useState([]);
   const [questionsCount, setQuestionsCount] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isQuestionSubmitted, setIsQuestionSubmitted] = useState(true);
+  const { canEditFeed } = useUser();
+
+  const navigate = useNavigate();
+  const isOwner = canEditFeed(id);
 
   useEffect(() => {
+    if (isAnswer && !isOwner) {
+      navigate('/403');
+    }
+
     if (!isQuestionSubmitted) return;
 
     const fetchSubject = async () => {
-      const response = await getSubjectById(id);
-      setSubject(response);
-
-      console.log(response);
+      try {
+        const response = await getSubjectById(id);
+        setSubject(response);
+      } catch (error) {
+        console.error('Error fetching subject:', error);
+      }
     };
 
     const fetchQuestions = async () => {
-      const response = await getQuestions(id);
-      const { count, results } = response;
-
-      setQuestions(results);
-      setQuestionsCount(count);
-
-      console.log(response);
+      try {
+        const response = await getQuestions(id);
+        const { count, results } = response;
+        setQuestions(results);
+        setQuestionsCount(count);
+      } catch (error) {
+        console.error('Error fetching questions:', error);
+      }
     };
 
     fetchSubject();
     fetchQuestions();
+
     setIsQuestionSubmitted(false);
   }, [id, isQuestionSubmitted]);
 
@@ -162,15 +175,13 @@ function FeedDetailPage() {
                 <QuestionCountText>{`${questionsCount}개의 질문이 있습니다.`}</QuestionCountText>
               </QuestionCounterContainer>
 
-              {console.log(questions)}
-              {console.log(answer)}
-
               {questions.map((question) => (
                 <QuestionBox
                   key={question.id}
                   question={question}
                   image={subject.imageSource}
                   name={subject.name}
+                  isOwner={isOwner}
                 />
               ))}
             </>

--- a/src/pages/FeedDetail/QuestionBox.jsx
+++ b/src/pages/FeedDetail/QuestionBox.jsx
@@ -267,16 +267,13 @@ const getRelativeTime = (dateString) => {
   return '방금 전';
 };
 
-export default function QuestionBox({ question, image, name }) {
+export default function QuestionBox({ question, image, name, isOwner }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [currentAnswer, setCurrentAnswer] = useState(question.answer);
   const [isEditing, setIsEditing] = useState(false);
   const [answerText, setAnswerText] = useState('');
   const [isLiked, setIsLiked] = useState(false);
   const [isDisliked, setIsDisliked] = useState(false);
-
-  const location = useLocation();
-  const isFeedOwner = location.pathname.includes('/post') && location.pathname.includes('/answer');
 
   const handleToggleMenu = () => {
     setMenuOpen((prev) => !prev);
@@ -407,7 +404,7 @@ export default function QuestionBox({ question, image, name }) {
         <AnswerTag $answered={!!currentAnswer || (currentAnswer && currentAnswer.isRejected)}>
           {currentAnswer ? '답변 완료' : '미답변'}
         </AnswerTag>
-        {isFeedOwner && (
+        {isOwner && (
           <KebabButton className='kebab-button-class' onClick={handleToggleMenu}>
             <img src='/images/icons/kebab-button.svg' alt='케밥 메뉴' />
           </KebabButton>
@@ -449,7 +446,7 @@ export default function QuestionBox({ question, image, name }) {
         <TitleInfo>질문 · {getRelativeTime(question.createdAt)}</TitleInfo>
         <Title className='actor-regular'>{question.content}</Title>
       </TitleContainer>
-      {isFeedOwner ? ( // 질문자인 경우
+      {isOwner ? ( // 질문자인 경우
         <AnswerContainer>
           <AnswerProfile src={image} alt='프로필 이미지' />
           <AnswerTextContainer>

--- a/src/pages/Home/HomepageForm.jsx
+++ b/src/pages/Home/HomepageForm.jsx
@@ -8,7 +8,7 @@ function HomeForm() {
   const [inputValue, setInputValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const navigate = useNavigate();
-  const { setUserId } = useUser();
+  const { setUser } = useUser();
 
   const handleChange = (e) => {
     const value = e.target.value;
@@ -29,17 +29,13 @@ function HomeForm() {
         const data = await createSubject(inputValue);
         console.log('API 응답:', data);
 
-        // 고유한 키 생성
-        const uniqueKey = `${new Date().getTime()}`;
-        const feedId = data.id;
-
-        navigate(`/post/${feedId}/answer`);
-        setUserId(uniqueKey);
-
-        // 로컬스토리지에 값 저장
-        localStorage.setItem(uniqueKey, inputValue);
+        // 생성한 subject의 id를 로컬 스토리지에 저장
+        const { id: feedId, name: ownerName } = data;
+        setUser(feedId, ownerName);
         setErrorMessage('');
         setInputValue('');
+
+        navigate(`/post/${feedId}/answer`);
       } catch (error) {
         setErrorMessage(error.message);
         console.error(error);


### PR DESCRIPTION
## 작업 내용

- answer 경로로 접근할 때, 로컬 스토리지에 `id`가 있는지를 확인하고 검증하는 로직 추가

## 이슈 번호

- 관련 이슈: #73 

## 변경 사항
  - `HomePage`에서 `id`생성시 해당 `id`를 `zustand store`로 로컬 스토리지에
    {id:name}의 형태로 저장
  - 저장한 값을 기반으로 `/answer` 경로일 때 로컬 스토리지에 해당 아이디가
    있는지를 검증
  - `id`가 있다면 `/answer`페이지 정상 랜더링
    - `QuestionBox` 에서 `isFeedOwner` 변수를 `location`을 사용해 만들던 방식에서, 상위 컴포넌트인 `FeedDetailPage`에서 `isOwner` prop을 전달하는 방식으로 변경.
  - 없다면 403에러 페이지 랜더링
    - ex: 자신이 만들지 않은 아이디의 `/post/id`에서 임의로 `/post/id/answer`경로를 통해 이동하려고 하면 403에러 페이지로 이동
  - 라우팅 되지 않은 경로 접근시 홈페이지로 `redirection`

## 리뷰 포인트
- 403 에러 페이지를 임시로 간단히 구현하였습니다.
- 여러 파일을 수정하였습니다. 수정 과정에서 이상한 부분은 없는지 확인 부탁드립니다.
- 중간중간 커밋을 하는 것을 잊고 하나의 커밋에 모두 담게 되었습니다. 양해 부탁드립니다.

## 참고 사항 (Screenshots/References)
![스크린샷 2024-11-02 180752](https://github.com/user-attachments/assets/21068820-5e42-415a-a65b-a6ffba506af3)

## 기타 사항
- 브랜치를 잘못 팠습니다. 작업하고보니 여러 파일들은 건드려서 feed-datail-page에서 나올 것이 아니라 develop에서 checkout하는 편이 나았을 것 같습니다. 제 실수입니다.
- `feature/3--feed-detail-page`로 우선 머지 후 `develop`으로도 mege하게되면 로컬 스토리지 구조를 변경하는 과정에서 기존에 작성하셨던 피드에서 answer 경로로 접근하실 수 없게 되실 겁니다. 질문 작성 및 수정 테스트를 하실 땐 새로 피드를 만들어서 사용해주셔야 합니다!
