### PR TITLE
FeedDetailPage 무한 스크롤 구현

### DIFF
--- a/src/api/questionApi.js
+++ b/src/api/questionApi.js
@@ -28,16 +28,19 @@ export async function createQuestions(subjectId, content) {
   }
 }
 
-// GET
-export async function getQuestions(subjectId) {
+export async function getQuestions(subjectId, limit = 10, offset = 0) {
   try {
     const response = await axios.get(`${BASE_URL}/subjects/${subjectId}/questions/`, {
       headers: DEFAULT_HEADERS,
+      params: { limit, offset },
     });
-
     return response.data;
   } catch (error) {
-    console.error('Error fetching questions:', error);
+    console.error(
+      `Error fetching questions for subject ${subjectId}:`,
+      error.response?.data || error.message,
+    );
+    throw error;
   }
 }
 

--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -123,7 +123,7 @@ const QuestionRegisterButton = styled.button`
   }
 `;
 
-function CreateQuestionModal({ id, image, name, setIsQuestionSubmitted, onClose }) {
+function CreateQuestionModal({ id, image, name, setCreatedQuestionsCount, setQuestions, onClose }) {
   const [questionText, setQuestionText] = useState('');
 
   const handleChange = (event) => {
@@ -132,11 +132,12 @@ function CreateQuestionModal({ id, image, name, setIsQuestionSubmitted, onClose 
 
   const handleSubmit = async () => {
     try {
-      await createQuestions(id, questionText);
+      const newQuestion = await createQuestions(id, questionText);
+      setQuestions((prevQuestions) => [newQuestion, ...prevQuestions]);
+      setCreatedQuestionsCount((prev) => prev + 1);
+
       alert('질문이 성공적으로 전송되었습니다.');
-      setIsQuestionSubmitted(true);
       onClose();
-      window.location.reload();
     } catch (error) {
       alert('질문 전송에 실패했습니다. 다시 시도해 주세요.');
     }

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -157,8 +157,6 @@ function FeedDetailPage({ isAnswer }) {
 
   useEffect(() => {
     fetchQuestions();
-    console.log(questions);
-    console.log(createdQuestoinsCount);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchQuestions]);
 
@@ -177,6 +175,7 @@ function FeedDetailPage({ isAnswer }) {
   const handleObserver = useCallback(
     (entries) => {
       const target = entries[0];
+
       if (target.isIntersecting && !isLoading && !isInitialLoad) {
         setPage((prevPage) => prevPage + 1);
       }

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -121,6 +121,8 @@ function FeedDetailPage({ isAnswer }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [createdQuestoinsCount, setCreatedQuestionsCount] = useState(0);
+  const [openMenuId, setOpenMenuId] = useState(null);
+
   const limit = window.innerWidth <= 768 ? 5 : 10;
 
   const fetchSubject = useCallback(async () => {
@@ -131,9 +133,6 @@ function FeedDetailPage({ isAnswer }) {
       console.error(error.message);
     }
   }, [id]);
-  const [isQuestionSubmitted, setIsQuestionSubmitted] = useState(true);
-  const { canEditFeed } = useUser();
-  const [openMenuId, setOpenMenuId] = useState(null);
 
   const fetchQuestions = useCallback(async () => {
     setIsLoading(true);
@@ -148,7 +147,6 @@ function FeedDetailPage({ isAnswer }) {
       setIsLoading(false);
       setIsInitialLoad(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, limit, page]);
 
   useEffect(() => {
@@ -160,7 +158,6 @@ function FeedDetailPage({ isAnswer }) {
 
   useEffect(() => {
     fetchQuestions();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchQuestions]);
 
   useEffect(() => {

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -1,7 +1,8 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import styled from 'styled-components';
 import Header from './Header.jsx';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import CreateQuestionModal from './CreateQuestionModal.jsx';
 import { getSubjectById } from '../../api/subjectApi.js';
 import { getQuestions } from '../../api/questionApi.js';
@@ -90,6 +91,7 @@ const CreateQuestionBtn = styled.button`
   box-shadow: ${(props) => props.theme.shadows['medium']};
   line-height: 26px;
   cursor: pointer;
+  overflow: auto;
 
   &::after {
     content: '질문 작성';
@@ -107,56 +109,83 @@ const CreateQuestionBtn = styled.button`
 
 function FeedDetailPage({ isAnswer }) {
   const { id } = useParams();
+  const navigate = useNavigate();
+  const { canEditFeed } = useUser();
+  const isOwner = canEditFeed(id);
+
   const [subject, setSubject] = useState({});
   const [questions, setQuestions] = useState([]);
   const [questionsCount, setQuestionsCount] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isQuestionSubmitted, setIsQuestionSubmitted] = useState(true);
-  const { canEditFeed } = useUser();
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [createdQuestoinsCount, setCreatedQuestionsCount] = useState(0);
+  const limit = window.innerWidth <= 768 ? 5 : 10;
 
-  const navigate = useNavigate();
-  const isOwner = canEditFeed(id);
+  const fetchSubject = useCallback(async () => {
+    try {
+      const response = await getSubjectById(id);
+      setSubject(response);
+    } catch (error) {
+      console.error(error.message);
+    }
+  }, [id]);
+
+  const fetchQuestions = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await getQuestions(id, limit, (page - 1) * limit + createdQuestoinsCount);
+      const { count, results } = response;
+      setQuestions((prevQuestions) => [...prevQuestions, ...results]);
+      setQuestionsCount(count);
+    } catch (error) {
+      console.error(error.message);
+    } finally {
+      setIsLoading(false);
+      setIsInitialLoad(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, limit, page]);
 
   useEffect(() => {
     if (isAnswer && !isOwner) {
       navigate('/403');
     }
-
-    if (!isQuestionSubmitted) return;
-
-    const fetchSubject = async () => {
-      try {
-        const response = await getSubjectById(id);
-        setSubject(response);
-      } catch (error) {
-        console.error('Error fetching subject:', error);
-      }
-    };
-
-    const fetchQuestions = async () => {
-      try {
-        const response = await getQuestions(id);
-        const { count, results } = response;
-        setQuestions(results);
-        setQuestionsCount(count);
-      } catch (error) {
-        console.error('Error fetching questions:', error);
-      }
-    };
-
     fetchSubject();
+  }, [fetchSubject, isAnswer, isOwner, navigate]);
+
+  useEffect(() => {
     fetchQuestions();
+    console.log(questions);
+    console.log(createdQuestoinsCount);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchQuestions]);
 
-    setIsQuestionSubmitted(false);
-  }, [id, isQuestionSubmitted, isOwner, isAnswer, navigate]);
+  useEffect(() => {
+    if (isInitialLoad) return;
 
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
+    const observer = new IntersectionObserver(handleObserver, { threshold: 0 });
+    const observerTarget = document.getElementById('observer');
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
+    if (observerTarget) {
+      observer.observe(observerTarget);
+    }
+    return () => observer.disconnect();
+  }, [isInitialLoad]);
+
+  const handleObserver = useCallback(
+    (entries) => {
+      const target = entries[0];
+      if (target.isIntersecting && !isLoading && !isInitialLoad) {
+        setPage((prevPage) => prevPage + 1);
+      }
+    },
+    [isLoading, isInitialLoad],
+  );
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
 
   return (
     <>
@@ -203,10 +232,13 @@ function FeedDetailPage({ isAnswer }) {
             id={id}
             image={subject.imageSource}
             name={subject.name}
-            setIsQuestionSubmitted={setIsQuestionSubmitted}
+            setCreatedQuestionsCount={setCreatedQuestionsCount}
+            setQuestions={setQuestions}
             onClose={handleCloseModal}
           />
         )}
+
+        <div id='observer' style={{ height: '10px' }}></div>
       </Main>
     </>
   );


### PR DESCRIPTION
## 작업 내용

- 무한 스크롤 구현

## 이슈 번호

- 관련 이슈: #82 

## 변경 사항
- 이제 개별 피드 페이지에서 질문을 한 번에 다 가져오지 않음
- 모바일 5개, 그 외 10개씩 요청
- view port에 컴포넌트 가장 밑에 있는 트리거 태그가 담기면 추가 데이터를 요청
- 질문을 새로 작성했을 시에도 순서가 밀리지 않도록 offset을 동적으로 조정

## 리뷰 포인트
- develop에 바로 머지하진 않고, 필요시 팀미팅때 보여드리겠습니다.
- 무한 스크롤이 잘 되는지 확인 부탁드립니다.
