### PR TITLE
feed-list-page 카드와 페이지네이션 지적사항 보완

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16783,7 +16783,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
       "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "invariant": "^2.2.4",
         "react-fast-compare": "^3.2.2",

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -9,24 +9,20 @@ const CardContainer = styled(Link)`
   position: relative;
   border: 1px solid ${({ theme }) => theme.gray[40]};
   border-radius: 16px;
-
   &:hover {
     border-color: ${({ theme }) => theme.red};
     opacity: 1;
     transform: translateY(-3px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }
-
   @media (min-width: 768px) {
     height: 187px;
     width: 220px;
   }
-
   @media (min-width: 868px) {
     min-width: 186px;
     max-width: 206.5px;
   }
-
   @media (min-width: 1200px) {
     width: 220px;
   }
@@ -34,7 +30,6 @@ const CardContainer = styled(Link)`
 
 const CardPadding = styled.div`
   padding: 16px;
-
   @media (min-width: 768px) {
     padding: 20px;
   }
@@ -45,7 +40,6 @@ const CardImage = styled.img`
   height: 48px;
   border-radius: 50%;
   mix-blend-mode: ${(props) => props.theme.mixBlendMode};
-
   @media (min-width: 768px) {
     width: 60px;
     height: 60px;
@@ -57,7 +51,6 @@ const CardName = styled.p`
   font-weight: ${({ theme }) => theme.typography.body2.fontWeight};
   margin-top: 12px;
   margin-bottom: 30px;
-
   @media (min-width: 768px) {
     font-size: ${({ theme }) => theme.typography.body1.fontSize};
     font-weight: ${({ theme }) => theme.typography.body1.fontWeight};
@@ -85,7 +78,6 @@ const CardQuestionTxt = styled.p`
   font-size: ${({ theme }) => theme.typography.caption1.fontSize};
   color: ${({ theme }) => theme.gray[40]};
   margin: 0;
-
   @media (min-width: 768px) {
     font-size: ${({ theme }) => theme.typography.body3.fontSize};
   }
@@ -94,7 +86,6 @@ const CardQuestionTxt = styled.p`
 const CardQuestionCount = styled.div`
   font-size: ${({ theme }) => theme.typography.caption1.fontSize};
   color: ${({ theme }) => theme.gray[40]};
-
   @media (min-width: 768px) {
     font-size: ${({ theme }) => theme.typography.body3.fontSize};
   }

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -23,12 +23,11 @@ const CardContainer = styled(Link)`
   }
 
   @media (min-width: 868px) {
-    height: 187px;
-    width: clamp(186px, 2.5vw + 186px, 206.5px);
+    min-width: 186px;
+    max-width: 206.5px;
   }
 
   @media (min-width: 1200px) {
-    height: 187px;
     width: 220px;
   }
 `;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -12,6 +12,9 @@ const CardContainer = styled(Link)`
 
   &:hover {
     border-color: ${({ theme }) => theme.red};
+    opacity: 1;
+    transform: translateY(-3px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }
 
   @media (min-width: 768px) {

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -6,7 +6,6 @@ const CardContainer = styled(Link)`
   height: 168px;
   width: 155.5px;
   background-color: ${({ theme }) => theme.gray[10]};
-  position: relative;
   border: 1px solid ${({ theme }) => theme.gray[40]};
   border-radius: 16px;
   &:hover {
@@ -20,8 +19,7 @@ const CardContainer = styled(Link)`
     width: 220px;
   }
   @media (min-width: 868px) {
-    min-width: 186px;
-    max-width: 206.5px;
+    width: calc(186px + (220 - 186) * ((100vw - 868px) / (1200 - 868)));
   }
   @media (min-width: 1200px) {
     width: 220px;

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -6,6 +6,7 @@ import Dropdown from './Dropdown';
 import UserCard from '../../components/Card';
 import Pagination from './Pagination';
 import { debounce } from 'lodash';
+import Loding from './Loading';
 
 const getPageSize = () => (window.innerWidth < 868 ? 6 : 8);
 
@@ -84,30 +85,29 @@ const PaginationContainer = styled.div`
   }
 `;
 
-const LoadingIndicator = styled.div`
-  text-align: center;
-  font-size: 18px;
-  color: ${({ theme }) => theme.gray[60]};
-`;
-
 function AllSubjects() {
   const [pageSize, setPageSize] = useState(8);
   const [subjectList, setSubjectList] = useState([]);
   const [sort, setSort] = useState('createdAt');
   const [page, setPage] = useState(1);
   const [totalPage, setTotalPage] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSortCard = (sortOption) => {
     setSort(sortOption);
   };
 
   const fetchData = useCallback(async () => {
-    setLoading(true);
-    const subjects = await getSubjects({ sort, page, pageSize });
-    setLoading(false);
-    setSubjectList(subjects.results);
-    setTotalPage(Math.ceil(subjects.count / pageSize));
+    setIsLoading(true);
+    try {
+      const subjects = await getSubjects({ sort, page, pageSize });
+      setSubjectList(subjects.results);
+      setTotalPage(Math.ceil(subjects.count / pageSize));
+    } catch (error) {
+      console.log('Error fetchingdata:', error);
+    } finally {
+      setIsLoading(false);
+    }
   }, [sort, pageSize, page]);
 
   useEffect(() => {
@@ -139,8 +139,8 @@ function AllSubjects() {
         <Dropdown onSortCard={handleSortCard} />
       </HeaderContainer>
       <GridContainer>
-        {loading ? (
-          <LoadingIndicator>Loading...</LoadingIndicator>
+        {isLoading ? (
+          <Loding />
         ) : (
           <UserCardGrid>
             {subjectList?.map((subject) => (

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -104,7 +104,6 @@ function AllSubjects() {
   const [totalPage, setTotalPage] = useState();
 
   const handleSortCard = (sortOption) => {
-    console.log('Selected sort option:', sortOption);
     setSort(sortOption);
   };
 

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -43,7 +43,7 @@ const HeaderContainer = styled.div`
 `;
 
 const Title = styled.p`
-  font-family: 'Actor', sans-serif;
+  font-family: 'Actor';
   font-size: 24px;
   font-weight: 400;
   margin-left: 24px;
@@ -123,7 +123,7 @@ function AllSubjects() {
       setPageSize(getPageSize());
     };
 
-    const debouncedHandleResize = debounce(handleResize, 250); // Debounce function
+    const debouncedHandleResize = debounce(handleResize, 250);
 
     window.addEventListener('resize', debouncedHandleResize);
     fetchData({ sort, page, pageSize });

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -8,11 +8,7 @@ import Pagination from './Pagination';
 import { debounce } from 'lodash';
 
 const getPageSize = () => {
-  const width = window.innerWidth;
-
-  if (width < 768) return 6;
-  else if (width < 868) return 6;
-  else if (width < 1200) return 8;
+  if (window.innerWidth < 868) return 6;
   else return 8;
 };
 

--- a/src/pages/FeedList/FeedList.jsx
+++ b/src/pages/FeedList/FeedList.jsx
@@ -4,10 +4,14 @@ import AllSubjects from './AllSubjects';
 import theme from '../../styles/theme';
 
 const Container = styled.div`
-  height: 100vh;
+  height: 105vh;
   display: flex;
   flex-direction: column;
   background-color: ${theme.gray[20]};
+
+  @media (min-width: 768px) {
+    height: 100vh;
+  }
 `;
 
 function FeedList() {

--- a/src/pages/FeedList/FeedList.jsx
+++ b/src/pages/FeedList/FeedList.jsx
@@ -4,7 +4,7 @@ import AllSubjects from './AllSubjects';
 import theme from '../../styles/theme';
 
 const Container = styled.div`
-  height: 105vh;
+  height: 120vh;
   display: flex;
   flex-direction: column;
   background-color: ${theme.gray[20]};

--- a/src/pages/FeedList/FeedList.jsx
+++ b/src/pages/FeedList/FeedList.jsx
@@ -10,7 +10,7 @@ const Container = styled.div`
   background-color: ${theme.gray[20]};
 
   @media (min-width: 768px) {
-    height: 100vh;
+    height: 105vh;
   }
 `;
 

--- a/src/pages/FeedList/Header.jsx
+++ b/src/pages/FeedList/Header.jsx
@@ -45,9 +45,11 @@ const StyledCommonBtn = styled(CommonBtn)`
 
 function Header() {
   const navigate = useNavigate();
-  const key = localStorage.key(0);
-
-  console.log(key);
+  const data = localStorage.getItem('user-storage');
+  const parsedData = JSON.parse(data);
+  const userIds = Object.keys(parsedData.state.users);
+  console.log(userIds[0]);
+  const key = userIds[0];
 
   const handleAnswerBtn = () => {
     const nextPath = key ? `/post/${key}/answer` : '/';

--- a/src/pages/FeedList/Header.jsx
+++ b/src/pages/FeedList/Header.jsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 import CommonBtn from '../../components/CommonButton';
 import theme from '../../styles/theme';
+import { useUser } from '../../hooks/useStore';
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -42,19 +43,17 @@ const StyledCommonBtn = styled(CommonBtn)`
   cursor: pointer;
 `;
 
-function Header({ subjectId }) {
-  console.log(subjectId);
-
+function Header() {
   const navigate = useNavigate();
+  const key = localStorage.key(0);
 
-  const handleAnswerBtn = (e) => {
-    const subjectId = localStorage.getItem('subjectId');
-    if (subjectId) {
-      navigate(`/post/${subjectId}/answer`);
-    } else {
-      navigate('/');
-    }
+  console.log(key);
+
+  const handleAnswerBtn = () => {
+    const nextPath = key ? `/post/${key}/answer` : '/';
+    navigate(nextPath);
   };
+
   return (
     <HeaderContainer>
       <Link to='/' aria-label='메인페이지이동'>

--- a/src/pages/FeedList/Header.jsx
+++ b/src/pages/FeedList/Header.jsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { Link, useNavigate } from 'react-router-dom';
 import CommonBtn from '../../components/CommonButton';
 import theme from '../../styles/theme';
-import { useUser } from '../../hooks/useStore';
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -45,11 +44,11 @@ const StyledCommonBtn = styled(CommonBtn)`
 
 function Header() {
   const navigate = useNavigate();
-  const data = localStorage.getItem('user-storage');
-  const parsedData = JSON.parse(data);
-  const userIds = Object.keys(parsedData.state.users);
-  console.log(userIds[0]);
-  const key = userIds[0];
+  const data = localStorage.getItem('user-storage'); // user-storage 키와 연결된 데이터를 검색
+  const parsedData = JSON.parse(data); // JS 객체로 구문 분석해서 state 및 users와 같은 속성에 문자열 대신 개체로 액세스
+  const userIds = Object.keys(parsedData.state.users); // 사용자 ID를 나타내는 parsedData.state 내의 users 객체에서 키를 추출
+  // console.log(userIds[userIds.length - 1]);
+  const key = userIds[userIds.length - 1]; // 가장 최근의 값을 가져옴
 
   const handleAnswerBtn = () => {
     const nextPath = key ? `/post/${key}/answer` : '/';

--- a/src/pages/FeedList/Loading.jsx
+++ b/src/pages/FeedList/Loading.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+// import SyncLoader from 'react-spinners/SyncLoader'; -> 스피너 회의 후 예상?
+
+const StyledLoding = styled.div`
+  position: fixed;
+  background-color: rgba(0, 0, 0, 0.4);
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+`;
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 1000px;
+  opacity: 0.5;
+`;
+
+const Loding = () => {
+  return (
+    <StyledLoding>
+      <StyledContainer>
+        <div>loading</div>
+      </StyledContainer>
+    </StyledLoding>
+  );
+};
+
+export default Loding;

--- a/src/pages/FeedList/Pagination.jsx
+++ b/src/pages/FeedList/Pagination.jsx
@@ -32,6 +32,11 @@ const PaginationButton = styled.div`
   width: 40px;
   height: 40px;
   cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+  }
 `;
 
 const Pagination = ({ totalPage, currentPage, pageChange }) => {

--- a/src/pages/FeedList/Pagination.jsx
+++ b/src/pages/FeedList/Pagination.jsx
@@ -51,13 +51,17 @@ const Pagination = ({ totalPage, currentPage, pageChange }) => {
 
   return (
     <PaginationContainer>
-      <PaginationButton disabled={currentPage === 1} onClick={() => pageChange(currentPage - 1)}>
+      <PaginationButton
+        disabled={currentPage === 1}
+        onClick={() => currentPage > 1 && pageChange(currentPage - 1)}
+        type='button'
+      >
         <img src='images/icons/Arrow-left.svg' alt='왼쪽화살표' />
       </PaginationButton>
       {pages.map((page) => (
         <PaginationButton
           key={page}
-          $isCurrentPage={currentPage === page} /* Pass the active state */
+          $isCurrentPage={currentPage === page}
           onClick={() => pageChange(page)}
         >
           {page}
@@ -65,7 +69,8 @@ const Pagination = ({ totalPage, currentPage, pageChange }) => {
       ))}
       <PaginationButton
         disabled={currentPage === totalPage}
-        onClick={() => pageChange(currentPage + 1)}
+        onClick={() => currentPage < totalPage && pageChange(currentPage + 1)}
+        type='button'
       >
         <img src='images/icons/A-right.svg' alt='오른쪽화살표' />
       </PaginationButton>


### PR DESCRIPTION
## 작업 내용
- 카드
- 페이지네이션

## 이슈 번호

- 관련 이슈: `#015`

## 변경 사항

- 카드: hover시 잠깐 올라가는 기능 추가
- 페이지네이션 마지막과 시작 멈춤 구현
- 카드 사이즈 점점 줄여지기
- 카드 8개 -> 6개시 보여지는 문제 로딩 추가

## 리뷰 포인트

- css요소적으로 문제있으면 알려주세요!

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
 
<img width="1440" alt="스크린샷 2024-11-04 오후 2 43 18" src="https://github.com/user-attachments/assets/8743a841-789f-4636-b789-f06c9121ba64">

- **모바일 버전 스크린샷**:
<img width="497" alt="스크린샷 2024-11-04 오후 2 43 52" src="https://github.com/user-attachments/assets/3610e474-4ab8-45a8-b9cd-e0c422a1b670">


## 기타 사항 (Additional Context)

- 지적 사항중 페이지네이션 들썩거림은 폰트 적용시 문제가 나타나는것 같습니다(제거시 들썩거림x). 그래서 일단 올라가는 듯한 호버 효과를 넣었는데 이것도 별로면 아예 호버 제외하고 폰트를 삭제하고 해야할 것 같습니다.
- 사이즈 줄이기는 했는데 8개에서 6개와 같이 페이지가 바뀌는 부분은 계속 시도 해봤는데 잘 적용이 안되네요. 그래서 로딩이 뜨게 구현은 해놨고 스피너를 이번 기회에 사용해봐도 좋을 것 같습니다.