### PR TITLE
HomepageForm.jsx부분에서 글자수 제한 유효성검사 추가

### DIFF
--- a/src/pages/Home/HomepageForm.jsx
+++ b/src/pages/Home/HomepageForm.jsx
@@ -14,8 +14,8 @@ function HomeForm() {
   const handleChange = (e) => {
     const value = e.target.value;
     setInputValue(value);
-    if (value.length > 8) {
-      setErrorMessage('8글자 안에 이름을 적어주세요');
+    if (value.length > 7) {
+      setErrorMessage('7글자 안에 이름을 적어주세요');
       setIsDisabled(true);
     } else {
       setInputValue(value);
@@ -23,7 +23,7 @@ function HomeForm() {
       setIsDisabled(false);
     }
 
-    if (value.trim() !== '' && value.length <= 8) {
+    if (value.trim() !== '' && value.length <= 7) {
       setErrorMessage('');
     }
   };

--- a/src/pages/Home/HomepageForm.jsx
+++ b/src/pages/Home/HomepageForm.jsx
@@ -7,20 +7,30 @@ import { useUser } from '../../hooks/useStore';
 function HomeForm() {
   const [inputValue, setInputValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [isDisabled, setIsDisabled] = useState(false);
   const navigate = useNavigate();
   const { setUser } = useUser();
 
   const handleChange = (e) => {
     const value = e.target.value;
     setInputValue(value);
-    if (value.trim() !== '') {
+    if (value.length > 8) {
+      setErrorMessage('8글자 안에 이름을 적어주세요');
+      setIsDisabled(true);
+    } else {
+      setInputValue(value);
+      setErrorMessage('');
+      setIsDisabled(false);
+    }
+
+    if (value.trim() !== '' && value.length <= 8) {
       setErrorMessage('');
     }
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (inputValue.trim() === '') {
+    if (isDisabled || inputValue.trim() === '') {
       setErrorMessage('이름을 입력하세요.');
     } else {
       console.log('제출할 이름:', inputValue);
@@ -57,7 +67,7 @@ function HomeForm() {
             />
           </HomeInputWrap>
           {errorMessage && <ErrorTxt $isVisible>{errorMessage}</ErrorTxt>}
-          <QuestionReceiveBtn as='button' type='submit'>
+          <QuestionReceiveBtn as='button' type='submit' disabled={isDisabled}>
             질문 받기
           </QuestionReceiveBtn>
         </HomeInputCon>


### PR DESCRIPTION
## 작업 내용

- HomepageForm.jsx부분에서 글자수 제한 유효성검사 추가

## 이슈 번호

- 관련 이슈: `#87`

## 변경 사항

- 8글자로 미팅시간에 얘기를 했지만 막상 반응형에서 살펴보니 7글자를 해야 다른ui들이 밀리지 않아서 제한을 7글자로 수정

## 리뷰 포인트

- 유효성 검사가 올바르게 작동하는지 확인부탁드립니다.

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/914a3cf1-4501-4b36-8261-47c3ce71998f)
- **모바일 버전 스크린샷**:
  ![image](https://github.com/user-attachments/assets/3617e980-7be8-4f27-ac65-598ed6e12632)

## 기타 사항 (Additional Context)

- x
