### PR TITLE
App.jsx에 있던 title,meta -> index.html로 이동

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>11-6팀 오픈마인드</title>
+    <meta name="keywords" content="기초프로젝트, 프론트앤드 11기 6팀, 오픈마인드, 코드잇" />
+    <meta
+      name="description"
+      content="익명성을 보장하며 CRUD(Create, Read, Update, Delete) 기능을 구현하는 웹 애플리케이션입니다."
+    />
+    <meta property="og:site_name" content="11-6팀 오픈마인드" />
+    <meta property="og:title" content="11-6팀 오픈마인드" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:description"
+      content="익명성을 보장하며 CRUD(Create, Read, Update, Delete) 기능을 구현하는 웹 애플리케이션입니다."
+    />
+    <meta
+      property="og:image"
+      content="https://open-mind-team-6.netlify.app/images/meta/SumMeta.png"
+    />
+    <meta property="og:url" content="https://open-mind-team-6.netlify.app/" />
+    <link rel="icon" href="/images/meta/favicon.ico" type="image/x-icon" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -19,30 +19,11 @@ function App() {
   return (
     <HelmetProvider>
       <Helmet>
-        <title>11-6팀 오픈마인드</title>
-        <meta name='keywords' content='기초프로젝트, 프론트앤드 11기 6팀, 오픈마인드, 코드잇' />
-        <meta
-          name='description'
-          content='익명성을 보장하며 CRUD(Create, Read, Update, Delete) 기능을 구현하는 웹 애플리케이션입니다.'
-        />
-        <meta property='og:site_name' content='11-6팀 오픈마인드' />
-        <meta property='og:title' content='11-6팀 오픈마인드' />
-        <meta property='og:type' content='website' />
-        <meta
-          property='og:description'
-          content='익명성을 보장하며 CRUD(Create, Read, Update, Delete) 기능을 구현하는 웹 애플리케이션입니다.'
-        />
-        <meta
-          property='og:image'
-          content='https://open-mind-team-6.netlify.app/images/meta/SumMeta.png'
-        />
-        <meta property='og:url' content='https://open-mind-team-6.netlify.app/' />
-        <link rel='icon' href='/images/meta/favicon.ico' type='image/x-icon' />
         <link href='https://fonts.googleapis.com/css2?family=Actor&display=swap' rel='stylesheet' />
         <link
           rel='stylesheet'
           as='style'
-          crossorigin
+          crossorigin='anonymous'
           href='https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css'
         />
       </Helmet>


### PR DESCRIPTION
## 작업 내용

- 처음 배포할때 개발자도구 검사를해서 head부분에 각 메타테그들이 잘 잡혀있길래 안심을 했으나 링크를 보낼때 노출이 안되어서 
- App.jsx에 있는 title, meta등 index.html로 이동

## 이슈 번호

- 관련 이슈: `#72`

## 변경 사항

- App.jsx에 있던 title,meta -> index.html로 이동
- crossorigin -> crossorigin='anonymous' 변경


## 리뷰 포인트

- 링크를 스스로한테 보내서 미리보기 이미지나, 설명, 등등 meta에 넣은게 노출이 잘되는지 확인부탁드립니다.
- 바로 노출이 안될수도 있으니 내일 확인해주시면 감사합니다!


## 기타 사항 (Additional Context)

- 만약 노출이 안되면 수요일 멘토링때 물어볼 생각입니다.
