### PR TITLE
FeedDetalPage 피드 삭제 기능 및 잘못된 answer 경로 검증 수정

### DIFF
--- a/src/api/subjectApi.js
+++ b/src/api/subjectApi.js
@@ -54,3 +54,17 @@ export async function getSubjectById(subjectId) {
     console.error('Error fetching subject:', error);
   }
 }
+
+// DELETE
+export async function deleteSubjectById(subjectId) {
+  try {
+    const response = await axios.delete(`${BASE_URL}/subjects/${subjectId}/`, {
+      headers: DEFAULT_HEADERS,
+    });
+
+    console.log(`Subject with ID ${subjectId} has been deleted successfully.`);
+    return response.data;
+  } catch (error) {
+    console.error('Error deleting subject:', error);
+  }
+}

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -18,15 +18,16 @@ const ToastMessage = styled.div`
   padding: 12px 20px;
   border-radius: 8px;
   font-size: 0.875rem;
-  animation: ${fadeInOut} 3s ease-in-out forwards;
-  z-index: 1000;
+  animation: ${fadeInOut} 5s ease-in-out forwards;
+  z-index: 1005;
 `;
 
 export default function Toast({ message, onClose }) {
   useEffect(() => {
     const timer = setTimeout(() => {
       onClose();
-    }, 3000);
+    }, 5000);
+
     return () => clearTimeout(timer);
   }, [onClose]);
 

--- a/src/pages/FeedDetail/ConFirmModal.jsx
+++ b/src/pages/FeedDetail/ConFirmModal.jsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import {
+  overlayFadeIn,
+  overlayFadeOut,
+  modalSlideUp,
+  modalSlideDown,
+} from '../../utills/modal-animation.js';
+
+const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: ${({ isVisible }) => (isVisible ? overlayFadeIn : overlayFadeOut)} 0.3s ease-out
+    forwards;
+`;
+
+const ModalContainer = styled.div`
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: ${({ theme }) => theme.shadows.large};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  animation: ${({ isVisible }) => (isVisible ? modalSlideUp : modalSlideDown)} 0.4s ease forwards;
+`;
+
+const ConfirmText = styled.p`
+  margin-bottom: 20px;
+  font-size: 1rem;
+  color: ${({ theme }) => theme.gray[80]};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const ConfirmButton = styled.button`
+  padding: 8px 16px;
+  background-color: ${({ theme }) => theme.brown[40]};
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+`;
+
+const CancelButton = styled.button`
+  padding: 8px 16px;
+  background-color: ${({ theme }) => theme.gray[30]};
+  color: ${({ theme }) => theme.gray[80]};
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+`;
+
+function ConfirmModal({ message, confirmText, onConfirm, onCancel, isVisible }) {
+  return (
+    <ModalOverlay isVisible={isVisible} onClick={onCancel}>
+      <ModalContainer isVisible={isVisible} onClick={(e) => e.stopPropagation()}>
+        <ConfirmText>{message}</ConfirmText>
+        <ButtonContainer>
+          <ConfirmButton onClick={onConfirm}>{confirmText}</ConfirmButton>
+          <CancelButton onClick={onCancel}>취소</CancelButton>
+        </ButtonContainer>
+      </ModalContainer>
+    </ModalOverlay>
+  );
+}
+
+export default ConfirmModal;

--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -1,7 +1,46 @@
-import styled from 'styled-components';
-import { useState } from 'react';
+import styled, { keyframes } from 'styled-components';
+import { useEffect, useState } from 'react';
 import { createQuestions } from '../../api/questionApi';
-import Toast from '../../components/Toast';
+
+const overlayFadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const overlayFadeOut = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
+const modalSlideUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const modalSlideDown = keyframes`
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+`;
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -15,6 +54,8 @@ const ModalOverlay = styled.div`
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  animation: ${({ isVisible }) => (isVisible ? overlayFadeIn : overlayFadeOut)} 0.2s ease-out
+    forwards;
 `;
 
 const ModalContainer = styled.div`
@@ -25,6 +66,7 @@ const ModalContainer = styled.div`
   padding: 24px;
   border-radius: 24px;
   box-shadow: ${(props) => props.theme.shadows['large']};
+  animation: ${({ isVisible }) => (isVisible ? modalSlideUp : modalSlideDown)} 0.4s ease forwards;
 `;
 
 const ModalTitle = styled.div`
@@ -135,6 +177,8 @@ function CreateQuestionModal({
   onToastshow,
 }) {
   const [questionText, setQuestionText] = useState('');
+  const [isVisible, setIsVisible] = useState(true);
+
   const handleChange = (event) => {
     setQuestionText(event.target.value);
   };
@@ -152,17 +196,22 @@ function CreateQuestionModal({
     }
   };
 
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(onModalClose, 400);
+  };
+
   const isButtonDisabled = questionText.trim() === '';
 
   return (
-    <ModalOverlay onClick={onModalClose}>
-      <ModalContainer onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay isVisible={isVisible} onClick={handleClose}>
+      <ModalContainer isVisible={isVisible} onClick={(e) => e.stopPropagation()}>
         <ModalTitle>
           <ModalTitleWrapper>
             <MessageIcon src='/images/icons/ic_messages_black.svg' />
             <ModalTitleText>질문을 작성하세요</ModalTitleText>
           </ModalTitleWrapper>
-          <CloseIcon onClick={onModalClose} src='/images/icons/ic_close.svg' />
+          <CloseIcon onClick={handleClose} src='/images/icons/ic_close.svg' />
         </ModalTitle>
 
         <ReceiverNicknameWrapper>

--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -1,46 +1,12 @@
-import styled, { keyframes } from 'styled-components';
-import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useState } from 'react';
 import { createQuestions } from '../../api/questionApi';
-
-const overlayFadeIn = keyframes`
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-`;
-
-const overlayFadeOut = keyframes`
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-`;
-
-const modalSlideUp = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-`;
-
-const modalSlideDown = keyframes`
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-`;
+import {
+  overlayFadeIn,
+  overlayFadeOut,
+  modalSlideUp,
+  modalSlideDown,
+} from '../../utills/modal-animation.js';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -189,8 +155,11 @@ function CreateQuestionModal({
       setQuestions((prevQuestions) => [newQuestion, ...prevQuestions]);
       setCreatedQuestionsCount((prev) => prev + 1);
 
-      onModalClose();
-      onToastshow();
+      setIsVisible(false);
+      setTimeout(() => {
+        onModalClose();
+        onToastshow();
+      }, 400);
     } catch (error) {
       alert('질문 전송에 실패했습니다. 다시 시도해 주세요.');
     }

--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { useState } from 'react';
 import { createQuestions } from '../../api/questionApi';
+import Toast from '../../components/Toast';
 
 const ModalOverlay = styled.div`
   position: fixed;
@@ -124,9 +125,16 @@ const QuestionRegisterButton = styled.button`
   }
 `;
 
-function CreateQuestionModal({ id, image, name, setCreatedQuestionsCount, setQuestions, onClose }) {
+function CreateQuestionModal({
+  id,
+  image,
+  name,
+  setCreatedQuestionsCount,
+  setQuestions,
+  onModalClose,
+  onToastshow,
+}) {
   const [questionText, setQuestionText] = useState('');
-
   const handleChange = (event) => {
     setQuestionText(event.target.value);
   };
@@ -137,8 +145,8 @@ function CreateQuestionModal({ id, image, name, setCreatedQuestionsCount, setQue
       setQuestions((prevQuestions) => [newQuestion, ...prevQuestions]);
       setCreatedQuestionsCount((prev) => prev + 1);
 
-      alert('질문이 성공적으로 전송되었습니다.');
-      onClose();
+      onModalClose();
+      onToastshow();
     } catch (error) {
       alert('질문 전송에 실패했습니다. 다시 시도해 주세요.');
     }
@@ -147,14 +155,14 @@ function CreateQuestionModal({ id, image, name, setCreatedQuestionsCount, setQue
   const isButtonDisabled = questionText.trim() === '';
 
   return (
-    <ModalOverlay onClick={onClose}>
+    <ModalOverlay onClick={onModalClose}>
       <ModalContainer onClick={(e) => e.stopPropagation()}>
         <ModalTitle>
           <ModalTitleWrapper>
             <MessageIcon src='/images/icons/ic_messages_black.svg' />
             <ModalTitleText>질문을 작성하세요</ModalTitleText>
           </ModalTitleWrapper>
-          <CloseIcon onClick={onClose} src='/images/icons/ic_close.svg' />
+          <CloseIcon onClick={onModalClose} src='/images/icons/ic_close.svg' />
         </ModalTitle>
 
         <ReceiverNicknameWrapper>

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -9,6 +9,7 @@ import { getQuestions } from '../../api/questionApi.js';
 import { useNavigate, useParams } from 'react-router-dom';
 import QuestionBox from './QuestionBox.jsx';
 import { useUser } from '../../hooks/useStore.js';
+import Toast from '../../components/Toast.jsx';
 
 const FeedDetailPageWrapper = styled.div`
   background-color: ${({ theme }) => theme.gray[20]};
@@ -126,6 +127,7 @@ function FeedDetailPage({ isAnswer }) {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [createdQuestoinsCount, setCreatedQuestionsCount] = useState(0);
   const [openMenuId, setOpenMenuId] = useState(null);
+  const [showToast, setShowToast] = useState(false);
 
   const limit = window.innerWidth <= 768 ? 5 : 10;
 
@@ -189,6 +191,8 @@ function FeedDetailPage({ isAnswer }) {
 
   const handleOpenModal = () => setIsModalOpen(true);
   const handleCloseModal = () => setIsModalOpen(false);
+  const handleShowToast = () => setShowToast(true);
+  const handleHideToast = () => setShowToast(false);
 
   const handleToggleMenu = (questionId) => {
     setOpenMenuId((prevId) => {
@@ -246,8 +250,13 @@ function FeedDetailPage({ isAnswer }) {
             name={subject.name}
             setCreatedQuestionsCount={setCreatedQuestionsCount}
             setQuestions={setQuestions}
-            onClose={handleCloseModal}
+            onModalClose={handleCloseModal}
+            onToastshow={handleShowToast}
           />
+        )}
+
+        {showToast && (
+          <Toast message={'질문이 성공적으로 작성되었습니다.'} onClose={handleHideToast} />
         )}
 
         <div id='observer' style={{ height: '10px' }}></div>

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -22,7 +22,6 @@ const Main = styled.main`
   flex-direction: column;
   align-items: center;
   padding: 0 24px;
-  // margin-top: 54px;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     padding: 0 32px;
@@ -146,6 +145,17 @@ const DeleteSubjectBtn = styled.button`
   }
 `;
 
+const Spacer = styled.div`
+  width: 70px;
+  height: 25px;
+  margin: 20px 0 12px;
+
+  @media (${(props) => props.theme.typography.device.tabletMn}) {
+    width: 116px;
+    height: 40px;
+  }
+`;
+
 function FeedDetailPage({ isAnswer }) {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -260,7 +270,7 @@ function FeedDetailPage({ isAnswer }) {
 
     setTimeout(() => {
       setIsDeleteCompleteModalOpen(false);
-      navigate('/list'); // 모달이 닫힌 후 이동
+      navigate('/list');
     }, 400);
   };
 
@@ -292,7 +302,11 @@ function FeedDetailPage({ isAnswer }) {
         questionsCount={questionsCount}
       />
       <Main>
-        <DeleteSubjectBtn onClick={handleOpenConfirmModal}>삭제하기</DeleteSubjectBtn>
+        {isAnswer && isOwner ? (
+          <DeleteSubjectBtn onClick={handleOpenConfirmModal}>삭제하기</DeleteSubjectBtn>
+        ) : (
+          <Spacer />
+        )}
         <QuestionsContainer>
           {questionsCount ? (
             <>
@@ -307,7 +321,7 @@ function FeedDetailPage({ isAnswer }) {
                   question={question}
                   image={subject.imageSource}
                   name={subject.name}
-                  isOwner={isOwner}
+                  isOwner={isAnswer && isOwner}
                   isMenuOpen={openMenuId === question.id}
                   onToggleMenu={() => handleToggleMenu(question.id)}
                 />

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -117,7 +117,7 @@ const DeleteSubjectBtn = styled.button`
   width: 70px;
   height: 25px;
   padding: 0 12px;
-  margin: 20px 0 8px;
+  margin: 20px 0 12px;
   font-size: 0.625rem;
   align-self: end;
   color: ${(props) => props.theme.gray[10]};
@@ -125,6 +125,25 @@ const DeleteSubjectBtn = styled.button`
   border: none;
   border-radius: 200px;
   box-shadow: ${(props) => props.theme.shadows['medium']};
+  cursor: pointer;
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
+
+  &:hover {
+    background-color: ${(props) => props.theme.brown[30]};
+    transform: scale(1.05);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  @media (${(props) => props.theme.typography.device.tabletMn}) {
+    width: 116px;
+    height: 40px;
+    font-size: ${(props) => props.theme.typography.body3.fontSize};
+  }
 `;
 
 function FeedDetailPage({ isAnswer }) {

--- a/src/utills/modal-animation.js
+++ b/src/utills/modal-animation.js
@@ -1,0 +1,41 @@
+import { keyframes } from 'styled-components';
+
+export const overlayFadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+export const overlayFadeOut = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
+export const modalSlideUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+export const modalSlideDown = keyframes`
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+`;


### PR DESCRIPTION
## 작업 내용
- FeedDetailPage에서의 (아마..?) 모든 기능 구현

## 변경 사항
- 피드 삭제 기능 추가
- 질문 작성, 삭제 시 등장하는 모달 창 애니메이션 추가
- 모달 컴포넌트 및 애니메이션 분리
- answer 검증 로직 구현

## 리뷰 포인트
- 삭제 기능이 정상적으로 동작해야 합니다.
- 삭제 확인 버튼을 클릭 시 `/list`페이지로 이동합니다.
- 자신이 현재 브라우저에서 만든 피드이면서(로컬스토리지에 id가 저장되어있는) answer 경로일 때만 피드 삭제하기 버튼 및 답변 기능이 랜더링 되어야 합니다.

## 참고 자료
![image](https://github.com/user-attachments/assets/88e550f3-2665-4999-88dc-3f1ff5688564)
![image](https://github.com/user-attachments/assets/587bbe88-5b8f-4781-8199-e55904e78c64)
![image](https://github.com/user-attachments/assets/6ec58544-7066-4f62-9f17-167eb4860492)


## 기타 사항 (Additional Context)
- 우선 거의 다 구현한 것 같은데, 아직 무한 스크롤 로딩 애니메이션은 넣지 못했습니다.
- 내일까지 위 작업 마무리하고, 수정이 필요한 부분이 있는지 검토하겠습니다.

---

11시까지 리뷰 받고 문제 없으면 다음 작업을 위해 머지하도록 하겠습니다.