### PR TITLE
FeedDetailPage 오류 수정

### DIFF
--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -139,6 +139,7 @@ function CreateQuestionModal({
   name,
   setCreatedQuestionsCount,
   setQuestions,
+  setQuestionsCount,
   onModalClose,
   onToastshow,
 }) {
@@ -153,6 +154,7 @@ function CreateQuestionModal({
     try {
       const newQuestion = await createQuestions(id, questionText);
       setQuestions((prevQuestions) => [newQuestion, ...prevQuestions]);
+      setQuestionsCount((prevCount) => prevCount + 1);
       setCreatedQuestionsCount((prev) => prev + 1);
 
       setIsVisible(false);

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -97,9 +97,17 @@ const CreateQuestionBtn = styled.button`
   line-height: 26px;
   cursor: pointer;
   overflow: auto;
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 
   &::after {
     content: '질문 작성';
+  }
+
+  &:hover {
+    background-color: ${(props) => props.theme.brown[50]};
+    transform: scale(1.05);
   }
 
   @media (${(props) => props.theme.typography.device.tabletMn}) {
@@ -130,7 +138,7 @@ const DeleteSubjectBtn = styled.button`
     transform 0.2s ease;
 
   &:hover {
-    background-color: ${(props) => props.theme.brown[30]};
+    background-color: ${(props) => props.theme.brown[50]};
     transform: scale(1.05);
   }
 
@@ -340,7 +348,8 @@ function FeedDetailPage({ isAnswer }) {
             </>
           )}
         </QuestionsContainer>
-        <CreateQuestionBtn onClick={handleOpenModal} />
+
+        {!(isAnswer && isOwner) && <CreateQuestionBtn onClick={handleOpenModal} />}
 
         {isModalOpen && (
           <CreateQuestionModal

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -159,7 +159,7 @@ const Spacer = styled.div`
 function FeedDetailPage({ isAnswer }) {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { canEditFeed } = useUser();
+  const { canEditFeed, removeUser } = useUser();
   const isOwner = canEditFeed(id);
 
   const [subject, setSubject] = useState({});
@@ -189,6 +189,7 @@ function FeedDetailPage({ isAnswer }) {
 
   const fetchQuestions = useCallback(async () => {
     setIsLoading(true);
+
     try {
       const response = await getQuestions(id, limit, (page - 1) * limit + createdQuestoinsCount);
       const { count, results } = response;
@@ -267,6 +268,7 @@ function FeedDetailPage({ isAnswer }) {
 
   const handleCloseDeleteCompleteModal = () => {
     setIsModalVisible(false);
+    removeUser(id);
 
     setTimeout(() => {
       setIsDeleteCompleteModalOpen(false);
@@ -347,6 +349,7 @@ function FeedDetailPage({ isAnswer }) {
             name={subject.name}
             setCreatedQuestionsCount={setCreatedQuestionsCount}
             setQuestions={setQuestions}
+            setQuestionsCount={setQuestionsCount}
             onModalClose={handleCloseQuestionModal}
             onToastshow={handleShowToast}
           />


### PR DESCRIPTION
## 작업 내용
- 피드에 첫 질문 작성 시 완료 후 보이지 않던 오류 수정
- 피드 삭제 시 로컬 스토리지에서는 id가 삭제되지 않던 오류 수정
- 질문 작성 버튼 랜더링 조건 수정

## 변경 사항

- 질문이 없는 경우를 감지하던 props의 값을 질문 생성 시 변경하도록 함
- `removeUser()` 함수를 사용해 피드 삭제 시 로컬 스토리지의 `id`도 함께 삭제.
- `질문 작성하기` 버튼이 이제 자신의 피드 answer 경로에선 보이지 않음.

## 리뷰 포인트
- 이제 질문이 0개인 피드에 첫 질문을 달아도 새로고침 없이 바로 질문이 보여야 합니다.
- 피드를 삭제했을 때, 로컬스토리지에서 해당 id도 삭제되어야 합니다.

## 기타 사항 (Additional Context)
- 어제 삭제 기능 추가 이후 피드를 삭제하신 분이 있다면, 답변하러 가기에서 나오는 피드들 중 접속 시 에러가 발생하는 경우가 있을 겁니다. 피드가 삭제되어 해당 `subjectId`로 값을 불러올 수 없어서 생기는 문제인데, 아마 최종 제출 전 서버의 데이터들을 한 번 초기화 해야 하지 않을까 싶습니다.
