### PR TITLE
feedlist 버튼의 드롭다운 스타일 추가

### DIFF
--- a/src/api/subjectApi.js
+++ b/src/api/subjectApi.js
@@ -30,13 +30,12 @@ export async function getSubjects({ sort, page, pageSize } = {}) {
     offset: page && pageSize ? (page - 1) * pageSize : undefined,
     sort: sort || undefined,
   };
-
   try {
     const response = await axios.get(`${BASE_URL}/subjects/`, {
       params: queryParams,
     });
-
-    return response.data;
+    const { results, count, next, previous } = response.data;
+    return { results, count, next, previous };
   } catch (error) {
     console.error('Failed to fetch subjects:', error);
     throw error;

--- a/src/api/subjectApi.js
+++ b/src/api/subjectApi.js
@@ -30,12 +30,13 @@ export async function getSubjects({ sort, page, pageSize } = {}) {
     offset: page && pageSize ? (page - 1) * pageSize : undefined,
     sort: sort || undefined,
   };
+
   try {
     const response = await axios.get(`${BASE_URL}/subjects/`, {
       params: queryParams,
     });
-    const { results, count, next, previous } = response.data;
-    return { results, count, next, previous };
+
+    return response.data;
   } catch (error) {
     console.error('Failed to fetch subjects:', error);
     throw error;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -10,9 +10,6 @@ const CardContainer = styled(Link)`
   border-radius: 16px;
   &:hover {
     border-color: ${({ theme }) => theme.red};
-    opacity: 1;
-    transform: translateY(-3px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }
   @media (min-width: 768px) {
     height: 187px;

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -59,6 +59,7 @@ const UserCardGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
+  overflow: hidden;
   @media (min-width: 768px) {
     grid-template-columns: repeat(3, 1fr);
   }
@@ -73,13 +74,13 @@ const UserCardGrid = styled.div`
 const PaginationContainer = styled.div`
   position: absolute;
   top: 820px;
-  @media ${theme.typography.device.tabletMn} {
+  @media (min-width: 768px) {
     top: 718px;
   }
   @media (min-width: 950px) {
     top: 701px;
   }
-  @media ${theme.typography.device.laptopMn} {
+  @media (min-width: 1200px) {
     top: 695px;
   }
 `;

--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -59,7 +59,6 @@ const UserCardGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1rem;
-  padding: 0 32px;
   @media (min-width: 768px) {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/src/pages/FeedList/Header.jsx
+++ b/src/pages/FeedList/Header.jsx
@@ -48,8 +48,9 @@ const Dropdown = styled.div`
   position: absolute;
   top: 100%;
   left: 0;
-  background-color: ${({ theme }) => theme.gray[20]};
-  border: 1px solid ${theme.black};
+  background-color: ${({ theme }) => theme.brown[10]};
+  border: 1px solid ${theme.brown[40]};
+  border-radius: 8px;
   padding: 3px 0;
   width: 120px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -61,17 +62,17 @@ const Dropdown = styled.div`
 `;
 
 const DropdownOption = styled.div`
-  margin-top: 4px;
-  border: 1px solid ${theme.gray[40]};
+  margin: 2px;
+  border: 1px solid ${theme.brown[40]};
   border-radius: 5px;
   text-align: center;
-  font-size: 20px;
-  font-weight: 400;
-  font-family: 'Pretendard';
-  line-height: 20px;
+  font-size: 14px;
+  font-weight: 300;
+  line-height: 14px;
   cursor: pointer;
   padding-top: 4px;
   padding-bottom: 4px;
+  color: ${theme.brown[40]};
   &:hover {
     color: ${({ theme }) => theme.red};
     border-color: ${({ theme }) => theme.red};

--- a/src/pages/FeedList/Header.jsx
+++ b/src/pages/FeedList/Header.jsx
@@ -49,7 +49,7 @@ const Dropdown = styled.div`
   top: 100%;
   left: 0;
   background-color: ${({ theme }) => theme.gray[20]};
-  border: 4px solid ${theme.brown[10]};
+  border: 1px solid ${theme.black};
   padding: 3px 0;
   width: 120px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -70,6 +70,8 @@ const DropdownOption = styled.div`
   font-family: 'Pretendard';
   line-height: 20px;
   cursor: pointer;
+  padding-top: 4px;
+  padding-bottom: 4px;
   &:hover {
     color: ${({ theme }) => theme.red};
     border-color: ${({ theme }) => theme.red};


### PR DESCRIPTION
## 작업 내용

- 버튼의 드롭 다운

## 이슈 번호

- 관련 이슈: `#015`

## 변경 사항

- 스타일 변경
- 카드 호버시 올라가는 듯한 느낌이 드는게 뭐를 잘못건드렸는지 맨 위가 짤려서 그냥 빨간색으로 표시되게만 해놨습니다(반응형 계속 해보고 시간 남으면 다른 애니메이션 있는지 찾아보고 적용하도록 할게요)
- 모바일 버전에서 왼쪽에 하얀색 화면 패딩값 삭제해서 수정

## 리뷰 포인트

- 스타일은 이정도면 될지 봐주세요

## 참고 사항 (Screenshots/References)

- **PC 버전 스크린샷**:
<img width="1438" alt="스크린샷 2024-11-05 오후 4 36 17" src="https://github.com/user-attachments/assets/4f84faef-7b76-4fa0-bd90-2c78ed678501">

- **모바일 버전 스크린샷**:
<img width="494" alt="스크린샷 2024-11-05 오후 4 37 17" src="https://github.com/user-attachments/assets/8e54aee1-489d-476b-a457-9f8611e72868">

## 기타 사항 (Additional Context)
