### PR TITLE
개별 피드 페이지 스타일 개선

### DIFF
--- a/src/pages/FeedDetail/CreateQuestionModal.jsx
+++ b/src/pages/FeedDetail/CreateQuestionModal.jsx
@@ -145,6 +145,9 @@ function CreateQuestionModal({
 }) {
   const [questionText, setQuestionText] = useState('');
   const [isVisible, setIsVisible] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isFormValid = questionText.trim() === '';
 
   const handleChange = (event) => {
     setQuestionText(event.target.value);
@@ -156,11 +159,13 @@ function CreateQuestionModal({
       setQuestions((prevQuestions) => [newQuestion, ...prevQuestions]);
       setQuestionsCount((prevCount) => prevCount + 1);
       setCreatedQuestionsCount((prev) => prev + 1);
+      setIsSubmitting(true);
 
       setIsVisible(false);
       setTimeout(() => {
         onModalClose();
         onToastshow();
+        setIsSubmitting(false);
       }, 400);
     } catch (error) {
       alert('질문 전송에 실패했습니다. 다시 시도해 주세요.');
@@ -171,8 +176,6 @@ function CreateQuestionModal({
     setIsVisible(false);
     setTimeout(onModalClose, 400);
   };
-
-  const isButtonDisabled = questionText.trim() === '';
 
   return (
     <ModalOverlay isVisible={isVisible} onClick={handleClose}>
@@ -197,7 +200,7 @@ function CreateQuestionModal({
           onChange={handleChange}
         />
 
-        <QuestionRegisterButton onClick={handleSubmit} disabled={isButtonDisabled}>
+        <QuestionRegisterButton onClick={handleSubmit} disabled={isFormValid || isSubmitting}>
           질문 보내기
         </QuestionRegisterButton>
       </ModalContainer>

--- a/src/pages/FeedDetail/FeedDetailPage.jsx
+++ b/src/pages/FeedDetail/FeedDetailPage.jsx
@@ -13,12 +13,11 @@ import Toast from '../../components/Toast.jsx';
 import ConfirmModal from './ConFirmModal.jsx';
 
 const FeedDetailPageWrapper = styled.div`
-  height: 100%;
+  min-height: 100vh;
   background-color: ${({ theme }) => theme.gray[20]};
 `;
 
 const Main = styled.main`
-  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/FeedDetail/Header.jsx
+++ b/src/pages/FeedDetail/Header.jsx
@@ -12,7 +12,10 @@ const HeaderContainer = styled.header`
 `;
 
 const BackGroundImage = styled.img`
+  width: 100%;
+  max-width: 1200px;
   height: 178px;
+  object-fit: cover;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
     height: 234px;
@@ -25,6 +28,7 @@ const LogoWrapper = styled(Link)`
 `;
 
 const Logo = styled.img`
+  width: 126px;
   height: 50px;
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
@@ -32,15 +36,33 @@ const Logo = styled.img`
   }
 `;
 
-const ProfileImage = styled.img`
+const ProfileImageWrap = styled.div`
   height: 104px;
-  margin-top: 100px;
+  width: 104px;
+  position: absolute;
+  top: 100px;
+  left: 50%;
+  transform: translate(-50%);
+  background-color: ${({ theme }) => theme.gray[10]};
+  border-radius: 50%;
+  overflow: hidden;
+
+  @media (${({ theme }) => theme.typography.device.tabletMn}) {
+    height: 136px;
+    width: 136px;
+    top: 130px;
+  }
+`;
+
+const ProfileImage = styled.img`
+  width: 104px;
+  height: 104px;
   border-radius: 50%;
   position: absolute;
   mix-blend-mode: ${(props) => props.theme.mixBlendMode};
+  background-color: #f0f0f0; /* 이미지가 로드되기 전 배경색 */
 
   @media (${({ theme }) => theme.typography.device.tabletMn}) {
-    margin-top: 130px;
     height: 136px;
     width: 136px;
   }
@@ -105,7 +127,9 @@ function Header({ id, image, name, questionsCount }) {
       <LogoWrapper to='/'>
         <Logo src='/images/contents/logo.svg' />
       </LogoWrapper>
-      <ProfileImage src={image} />
+      <ProfileImageWrap>
+        <ProfileImage src={image} />
+      </ProfileImageWrap>
       <UserName>{name}</UserName>
       <ShareContainer>
         <CopyUrlBtn onClick={copyCurrentUrl}>


### PR DESCRIPTION
## 작업 내용

- 헤더 이미지 크기 지정
- 블랙 모드 레이아웃 오류 해결
- 질문 연타 버그 해결

## 이슈 번호

- 관련 이슈: #95 


## 변경 사항
- 프로필과 로고 이미지에 절대 크기를 지정해서, 로딩이 되지 않아도 배치 영역을 확보하도록 함
- 모바일에서 헤더 배경 이미지가 삐져나오는 문제를 `max-width`와 `object-fit`속성을 사용해 해결
- 블랙 모드 시 흰색 여백이 생기는 문제를 `min-height`속성으로 배경 영역을 확보하여 해결
- 질문 버튼 연타 시 질문이 연속적으로 전송되던 부분에 상태를 추가하여 전송중임을 검증하도록 함

## 리뷰 포인트
- 핵심적인 오류였던 질문 보내기 연타 문제를 해결했습니다.
- 스타일적으로 개선 사항이 있으면 알려주시면 좋겠습니다!

