### PR TITLE
FeedList 페이지 스피너, 페이지네이션 수정

### DIFF
--- a/src/pages/FeedList/AllSubjects.jsx
+++ b/src/pages/FeedList/AllSubjects.jsx
@@ -28,12 +28,15 @@ function AllSubjects() {
       const subjects = await getSubjects({ sort, page, pageSize });
       setSubjectList(subjects.results);
       setTotalPage(Math.ceil(subjects.count / pageSize));
+      if (subjects.results.length === 0 && page !== totalPage) {
+        setPage(totalPage);
+      }
     } catch (error) {
       console.log('Error fetchingdata:', error);
     } finally {
       setIsLoading(false);
     }
-  }, [sort, pageSize, page]);
+  }, [sort, pageSize, page, totalPage]);
 
   useEffect(() => {
     fetchData();
@@ -41,17 +44,17 @@ function AllSubjects() {
 
   useEffect(() => {
     const handleResize = () => {
-      setPageSize(getPageSize());
+      const newPageSize = getPageSize(); // 새로운 페이지 사이즈 계산
+      setPageSize(newPageSize); // 페이지 사이즈 상태 업데이트
     };
 
-    const debouncedHandleResize = debounce(handleResize, 250);
-
-    window.addEventListener('resize', debouncedHandleResize);
+    const debouncedHandleResize = debounce(handleResize, 250); // 리사이즈를 디바운스 처리하여 성능 최적화
+    window.addEventListener('resize', debouncedHandleResize); // 리사이즈 이벤트 리스너 추가
 
     return () => {
-      window.removeEventListener('resize', debouncedHandleResize);
+      window.removeEventListener('resize', debouncedHandleResize); // 컴포넌트 언마운트 시 리사이즈 이벤트 리스너 제거
     };
-  }, []);
+  }, [subjectList]); // subjectList가 변경될 때마다 리사이즈 처리
 
   const pageChange = (pageNum) => {
     setPage(pageNum);

--- a/src/pages/FeedList/Loading.jsx
+++ b/src/pages/FeedList/Loading.jsx
@@ -15,7 +15,6 @@ export default Loding;
 
 const StyledLoding = styled.div`
   position: fixed;
-  background-color: rgba(0, 0, 0, 0.4);
   left: 0;
   top: 0;
   width: 100%;


### PR DESCRIPTION
## 작업 내용
- 스피너
- 페이지네이션

## 이슈 번호

- 관련 이슈: `#015`
  - **이슈 번호**를 명시하면 GitHub에서 PR이 이슈와 연동.

## 변경 사항

- 스피너 배경색 제거
- 페이지네이션 모바일에서와 PC에서의 페이지 수가 달라 나오는 문제를 API가 존재하지않는다면, 마지막 페이지로 갈수있게 설계

## 리뷰 포인트

- 중복코드가 없는지 봐주세요

## 참고 사항 (Screenshots/References)

- **스피너**:
<img width="1920" alt="스크린샷 2024-11-06 오후 10 25 45" src="https://github.com/user-attachments/assets/fce985f3-2efa-4e53-afc2-2a8c2cc726c1">

- **페이지네이션**:
**모바일**
<img width="502" alt="스크린샷 2024-11-06 오후 10 26 27" src="https://github.com/user-attachments/assets/ceb4d5e5-914a-4fb4-9800-3111be0da320">

**데스크탑**
<img width="1208" alt="스크린샷 2024-11-06 오후 10 26 39" src="https://github.com/user-attachments/assets/b30c1de5-5352-42fc-9549-9280962a51d6">

## 기타 사항 (Additional Context)
